### PR TITLE
Fix ROOT-006 cleanup unused imports

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -4,7 +4,6 @@
 import { HumanPlayer } from './src/cli/human-player'
 import { TextAdventure } from './src/games/text-adventure'
 import { TerminalUI } from './src/cli/terminal-ui'
-import type { GameResult } from './src/types'
 
 async function main() {
   const args = process.argv.slice(2)

--- a/packages/playtest/src/ai/api/openai.ts
+++ b/packages/playtest/src/ai/api/openai.ts
@@ -3,9 +3,7 @@ import { z } from "zod";
 import { toJsonSchema } from "../../schema/utils";
 import type { JsonSchema7Type } from "zod-to-json-schema";
 import OpenAI from "openai";
-import { observeOpenAI, Langfuse } from "langfuse";
-
-// const langfuse = new Langfuse();
+import { observeOpenAI } from "langfuse";
 
 /**
  * Tool definition with Zod schema


### PR DESCRIPTION
## Summary
- remove unused `Langfuse` import from OpenAI API helper
- drop stale `GameResult` import from root index

## Testing
- `bun run typecheck` *(fails: HumanPlayer and other issues)*